### PR TITLE
With rspec 2.10.1, it should be "require 'rspec'" instead of "require 'spec'"

### DIFF
--- a/rubygems_generators/install_cucumber/templates/features/support/env.rb.erb
+++ b/rubygems_generators/install_cucumber/templates/features/support/env.rb.erb
@@ -3,7 +3,7 @@ require File.dirname(__FILE__) + "/../../lib/<%= project_name %>"
 gem 'cucumber'
 require 'cucumber'
 gem 'rspec'
-require 'spec'
+require 'rspec'
 
 Before do
   @tmp_root = File.dirname(__FILE__) + "/../../tmp"


### PR DESCRIPTION
This patch fixes this error seen when running `cucumber` after doing `./script/generate install_cucumber` on a project created with newgem.

cannot load such file -- spec (LoadError)
/Users/aaron/.rvm/rubies/ruby-1.9.3-p125/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
/Users/aaron/.rvm/rubies/ruby-1.9.3-p125/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in`require'
/Users/aaron/Documents/workspace/project_lint/features/support/env.rb:6:in `<top (required)>'
/Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/cucumber-1.2.1/lib/cucumber/rb_support/rb_language.rb:129:in`load'
/Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/cucumber-1.2.1/lib/cucumber/rb_support/rb_language.rb:129:in `load_code_file'
/Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/cucumber-1.2.1/lib/cucumber/runtime/support_code.rb:171:in`load_file'
/Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/cucumber-1.2.1/lib/cucumber/runtime/support_code.rb:83:in `block in load_files!'
/Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/cucumber-1.2.1/lib/cucumber/runtime/support_code.rb:82:in`each'
/Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/cucumber-1.2.1/lib/cucumber/runtime/support_code.rb:82:in `load_files!'
/Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/cucumber-1.2.1/lib/cucumber/runtime.rb:175:in`load_step_definitions'
/Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/cucumber-1.2.1/lib/cucumber/runtime.rb:40:in `run!'
/Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/cucumber-1.2.1/lib/cucumber/cli/main.rb:43:in`execute!'
/Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/cucumber-1.2.1/lib/cucumber/cli/main.rb:20:in `execute'
/Users/aaron/.rvm/gems/ruby-1.9.3-p125/gems/cucumber-1.2.1/bin/cucumber:14:in`<top (required)>'
/Users/aaron/.rvm/gems/ruby-1.9.3-p125/bin/cucumber:19:in `load'
/Users/aaron/.rvm/gems/ruby-1.9.3-p125/bin/cucumber:19:in`<main>'
