### PR TITLE
Update matchers.rb template for rspec 2

### DIFF
--- a/rubygems_generators/install_cucumber/templates/features/support/matchers.rb
+++ b/rubygems_generators/install_cucumber/templates/features/support/matchers.rb
@@ -1,11 +1,13 @@
-module Matchers
-  def contain(expected)
-    simple_matcher("contain #{expected.inspect}") do |given, matcher|
-      matcher.failure_message = "expected #{given.inspect} to contain #{expected.inspect}"
-      matcher.negative_failure_message = "expected #{given.inspect} not to contain #{expected.inspect}"
-      given.index expected
-    end
+RSpec::Matchers.define :contain do |expected|
+  match do |actual|
+    actual.index expected
+  end
+  
+  failure_message_for_should do |actual|
+    "expected #{actual.inspect} to contain #{expected.inspect}"
+  end
+
+  failure_message_for_should_not do |actual|
+    "expected #{actual.inspect} not to contain #{expected.inspect}"
   end
 end
-
-World(Matchers)


### PR DESCRIPTION
simple_matcher no longer exists in rspec 2.

```
  undefined method `simple_matcher' for #<Object:0x007ff97910c528> (NoMethodError)
  ./features/support/matchers.rb:3:in `contain'
  ./features/step_definitions/common_steps.rb:16:in `/^I will be told "(.*?)"$/'
  features/remove_jbehave.feature:7:in `<...snip...>'
```
